### PR TITLE
Add chartjs-plugin-annotation

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
         "chroma-js": "^2.1.2",
         "markdown-tables-to-json": "^0.1.7",
         "svelte": "^3.35.0",
-        "vanilla-picker": "^2.11.2"
+        "vanilla-picker": "^2.11.2",
+        "chartjs-plugin-annotation": "^2.2.1"
     },
     "moduleFileExtensions": [
         "js",

--- a/src/chartRenderer.ts
+++ b/src/chartRenderer.ts
@@ -5,7 +5,9 @@ import { generateInnerColors, renderError } from 'src/util';
 import type { ChartPluginSettings, ImageOptions } from './constants/settingsConstants';
 import type ChartPlugin from 'src/main';
 import { generateTableData } from 'src/chartFromTable';
-Chart.register(...registerables);
+import annotationPlugin from 'chartjs-plugin-annotation'
+
+Chart.register(...registerables, annotationPlugin);
 
 // I need to refactor this
 // Or just rewrite it completely

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,6 +184,11 @@
   "resolved" "https://registry.npmjs.org/chart.js/-/chart.js-3.9.1.tgz"
   "version" "3.9.1"
 
+"chartjs-plugin-annotation@^2.2.1":
+  "integrity" "sha512-RL9UtrFr2SXd7C47zD0MZqn6ZLgrcRt3ySC6cYal2amBdANcYB1QcwFXcpKWAYnO4SGJYRok7P5rKDDNgJMA/w=="
+  "resolved" "https://registry.yarnpkg.com/chartjs-plugin-annotation/-/chartjs-plugin-annotation-2.2.1.tgz#b7c359e46814b27632d9648584435d64c183427c"
+  "version" "2.2.1"
+
 "chokidar@^3.4.1":
   "integrity" "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw=="
   "resolved" "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz"


### PR DESCRIPTION
Add chartjs-plugin-annotation to package.json and import from chartRenderer.ts.

This is a fix for issue #35.

I've only tested using the chartjs-plugin-annotation from Javascript code blocks and it works just fine. I don't use the YAML method for creating charts, so I didn't test that approach.

**Note**: I hand edited yarn.lock to reflect the new package. `npm` and `yarn` both rewrote the whole file, removing quotes and changing the order of properties. I thought it would be better to limit the updates to just the new package.