### PR TITLE
Empty-value handling and title modifier

### DIFF
--- a/docusaurus/docs/Modifiers.mdx
+++ b/docusaurus/docs/Modifiers.mdx
@@ -191,6 +191,51 @@ Determines where the legend will be displayed.
 - Expected `top`, `left`, `bottom`, `right`
 - Default: `top`
 
+## `title` Modifier
+
+Adds a title/caption above (or around) the chart.
+
+- Expected: `string`
+- Default: none (no title is shown)
+
+### Example
+
+````yaml
+```chart
+    type: line
+    labels: [Monday,Tuesday,Wednesday,Thursday,Friday]
+    series:
+        - title: Title 1
+        data: [4,2,3,4,5]
+        - title: Title 2
+        data: [5,4,3,2,2]
+        - title: Title 3
+        data: [8,2,5,3,4]
+    title: My Chart Title
+```
+````
+
+## `titlePosition` Modifier
+
+Determines where the chart title will be displayed.
+
+- Expected `top`, `left`, `bottom`, `right`
+- Default: `top`
+
+## `titleColor` Modifier
+
+Sets the color of the chart title.
+
+- Expected: any valid CSS color
+- Default: adapts automatically to the current Obsidian theme (dark text on light themes, light text on dark themes)
+
+## `titleFontSize` Modifier
+
+Sets the font size (in px) of the chart title.
+
+- Expected: `int`
+- Default: `12`
+
 ## Axes Modifiers
 
 Valid for `bar` and `line` types only. 

--- a/src/chartFromTable.ts
+++ b/src/chartFromTable.ts
@@ -9,7 +9,7 @@ type: bar
 labels: [${labels}]
 series:
 ${dataFields
-    .map((data) => `  - title: ${data.dataTitle}\n    data: [${data.data}]`)
+    .map((data) => `  - title: ${data.dataTitle}\n    data: [${(data.data as (string | null)[]).map((value) => value === null ? 'null' : value).join(', ')}]`)
     .join("\n")}
 width: 80%
 beginAtZero: true
@@ -30,9 +30,14 @@ export function generateTableData(table: string, layout: 'columns' | 'rows', sel
     let dataFields: DataField[] = Object.keys(fields).map((key) => {
         return {
             dataTitle: key,
-            data: Object.values(fields[key]) as string[]
+            data: (Object.values(fields[key]) as string[]).map((value) => value === undefined || value === null || value.trim() === '' ? null : value)
         }
     });
+
+    dataFields = dataFields.filter((field) =>
+        field.dataTitle.trim() !== '' ||
+        (field.data as (string | null)[]).some((value) => value !== null)
+    );
 
     if(selected) {
         dataFields = dataFields.filter(value => selected.contains(value.dataTitle));

--- a/src/chartRenderer.ts
+++ b/src/chartRenderer.ts
@@ -69,17 +69,36 @@ export default class Renderer {
 
         let chartOptions: ChartConfiguration;
 
-        Chart.defaults.color = yaml.textColor || getComputedStyle(el).getPropertyValue('--text-muted');
-        Chart.defaults.font.family = getComputedStyle(el).getPropertyValue('--mermaid-font');
-        Chart.defaults.plugins = {
-            ...Chart.defaults.plugins,
-            legend: {
-                ...Chart.defaults.plugins.legend,
-                display: yaml.legend ?? true,
-                position: yaml.legendPosition ?? "top",
+        // NOTE: these must be set per-chart-instance (options.*) rather than on the
+        // shared, global Chart.defaults. Obsidian renders each chart codeblock via an
+        // async postprocessor, so multiple charts on the same page can render
+        // concurrently/interleaved - mutating Chart.defaults here caused one chart's
+        // title/legend/color/font/padding settings to leak into another chart's render.
+        const baseOptions = {
+            color: yaml.textColor || getComputedStyle(el).getPropertyValue('--text-muted'),
+            font: {
+                family: getComputedStyle(el).getPropertyValue('--mermaid-font'),
+            },
+            layout: {
+                padding: yaml.padding,
+            },
+            plugins: {
+                legend: {
+                    display: yaml.legend ?? true,
+                    position: yaml.legendPosition ?? "top",
+                },
+                title: {
+                    display: !!yaml.title,
+                    text: yaml.title,
+                    position: yaml.titlePosition ?? "top",
+                    color: yaml.titleColor || getComputedStyle(el).getPropertyValue('--text-normal'),
+                    font: {
+                        weight: 'bold',
+                        size: yaml.titleFontSize ?? 12,
+                    },
+                },
             },
         };
-        Chart.defaults.layout.padding = yaml.padding;
 
         if (yaml.type == 'radar' || yaml.type == 'polarArea') {
             (chartOptions as ChartConfiguration<"polarArea" | "radar">) = {
@@ -89,6 +108,7 @@ export default class Renderer {
                     datasets
                 },
                 options: {
+                    ...baseOptions,
                     animation: {
                         duration: 0
                     },
@@ -115,6 +135,7 @@ export default class Renderer {
                     datasets
                 },
                 options: {
+                    ...baseOptions,
                     animation: {
                         duration: 0
                     },
@@ -181,6 +202,7 @@ export default class Renderer {
                     datasets,
                 },
                 options: {
+                    ...baseOptions,
                     animation: {
                         duration: 0
                     },
@@ -194,6 +216,7 @@ export default class Renderer {
                     datasets
                 },
                 options: {
+                    ...baseOptions,
                     animation: {
                         duration: 0
                     },

--- a/src/constants/settingsConstants.ts
+++ b/src/constants/settingsConstants.ts
@@ -29,5 +29,5 @@ export interface ImageOptions {
 
 export interface DataField {
     dataTitle: string;
-    data: string | string[];
+    data: string | (string | null)[];
 }


### PR DESCRIPTION
## Changed:
- Blank Markdown table cells are treated as missing values instead of being coerced to 0, and table-to-chart conversion now skips columns with a blank header and all-blank cells.
- Added a title modifier (with titlePosition, titleColor, titleFontSize) for chart captions, defaulting to a theme-adaptive color.